### PR TITLE
drop -R from chmod 

### DIFF
--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -63,7 +63,7 @@ spec:
         securityContext:
           privileged: true
       - name: fixmount
-        command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
+        command: [ 'sh', '-c', 'chown 1000:1000 /usr/share/elasticsearch/data' ]
         image: busybox
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -76,7 +76,7 @@ spec:
         securityContext:
           privileged: true
       - name: fixmount
-        command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
+        command: [ 'sh', '-c', 'chown 1000:1000 /usr/share/elasticsearch/data' ]
         image: busybox
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data


### PR DESCRIPTION
chmod -R fails if the volume contains ro subdirectories (e.g. .snapshot/ on NFS shares) 