### PR TITLE
Upgrade from upstream and password management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 deploy.yaml
+upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,22 @@
 
 # 0.1.5
 - Ignore efk-stack-app namespace in fluentd
+
+# 0.2.0
+## Opendistro
+- Upgrade to OpenDistro 1.6.0
+- Add pod affinity
+- Allow subpath for Persistent Volumes
+- Allow use of unmanaged Persistent Volumes
+- Configurable init images
+
+## FluentD
+- Upgrade fluentD version
+- Get auth from secret
+
+## ElasticSearch Exporter
+- Get auth info from secret
+- `prometheusRule.rules` are now processed as Helm template, allowing to set variables in them. This means that if a rule contains a {{ $value }}, Helm will try replacing it and probably fail.
+
+## ElasticSearch Curator
+- Get auth info from secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@
 
 # 0.2.0
 ## Opendistro
-- Upgrade to OpenDistro 1.6.0
+- Upgrade to OpenDistro 1.6.0 [Changelog](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/release-notes-odfe-1.6.0.md)
 - Add pod affinity
 - Allow subpath for Persistent Volumes
 - Allow use of unmanaged Persistent Volumes
 - Configurable init images
 
 ## FluentD
-- Upgrade fluentD version
+- Upgrade fluentD version to 3.0.0
 - Get auth from secret
 
 ## ElasticSearch Exporter

--- a/example_values/ingress_enabled_aws.yaml
+++ b/example_values/ingress_enabled_aws.yaml
@@ -7,18 +7,20 @@ opendistro-es:
         kubernetes.io/tls-acme: "true"
       path: /
       hosts:
-        - kibana.5f3kb.k8s.gauss.eu-central-1.aws.gigantic.io
+        - kibana.f6cau.k8s.gauss.eu-central-1.aws.gigantic.io
       tls:
        - secretName: kibana-tls
          hosts:
-           - kibana.5f3kb.k8s.gauss.eu-central-1.aws.gigantic.io
+           - kibana.f6cau.k8s.gauss.eu-central-1.aws.gigantic.io
 
   elasticsearch:
     master:
-      storageClassName: gp2
-      storage: 50Gi
+      persistence:
+        storageClass: gp2
+        size: 50Gi
 
     data:
-      storageClassName: gp2
-      storage: 100Gi
+      persistence:
+        storageClass: gp2
+        size: 100Gi
     

--- a/example_values/ingress_enabled_aws_custompvc.yaml
+++ b/example_values/ingress_enabled_aws_custompvc.yaml
@@ -7,19 +7,21 @@ opendistro-es:
         kubernetes.io/tls-acme: "true"
       path: /
       hosts:
-        - kibana.x5xg2.k8s.ghost.westeurope.azure.gigantic.io
+        - kibana.f6cau.k8s.gauss.eu-central-1.aws.gigantic.io
       tls:
        - secretName: kibana-tls
          hosts:
-           - kibana.x5xg2.k8s.ghost.westeurope.azure.gigantic.io
+           - kibana.f6cau.k8s.gauss.eu-central-1.aws.gigantic.io
 
   elasticsearch:
     master:
       persistence:
-        storageClass: default
+        storageClass: gp2
         size: 50Gi
+        subPath: master
 
     data:
       persistence:
-        storageClass: default
+        storageClass: gp2
         size: 100Gi
+        subPath: data

--- a/example_values/security_config.yaml
+++ b/example_values/security_config.yaml
@@ -1,60 +1,14 @@
-fluentd-elasticsearch:
-  elasticsearch:
-    host: efk-stack-app-opendistro-es-client-service
-    auth:
-      user: "admin"
-      password: "test"
-
-elasticsearch-curator:
-  enabled: true
-  configMaps:
-    # Delete indices older than 7 days
-    action_file_yml: |-
-      ---
-      actions:
-        1:
-          action: delete_indices
-          description: "Clean up ES by deleting old indices"
-          options:
-            timeout_override:
-            continue_if_exception: False
-            disable_action: False
-            ignore_empty_list: True
-          filters:
-          - filtertype: age
-            source: name
-            direction: older
-            timestring: '%Y.%m.%d'
-            unit: days
-            unit_count: 3
-            field:
-            stats_result:
-            epoch:
-            exclude: False
-    # Having config_yaml WILL override the other config
-    config_yml: |-
-      ---
-      client:
-        hosts:
-          - efk-stack-app-opendistro-es-client-service
-        port: 9200
-        http_auth: admin:test
-
-elasticsearch-exporter:
-  enabled: true
-  es:
-    uri: http://admin:test@efk-stack-app-opendistro-es-client-service:9200
-
-
 opendistro-es:
   elasticsearch:
     master:
-      storageClassName: gp2
-      storage: 50Gi
+      persistence:
+        storageClass: gp2
+        size: 50Gi
 
     data:
-      storageClassName: gp2
-      storage: 100Gi
+      persistence:
+        storageClass: gp2
+        size: 100Gi
     
     # kubectl create secret generic -n efk-stack-app opendistro-security-config --from-file=config_examples/config.yml
     # kubectl create secret generic -n efk-stack-app opendistro-internal-users --from-file=config_examples/internal_users.yml

--- a/helm/efk-stack-app/charts/elasticsearch-curator/templates/cronjob.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-curator/templates/cronjob.yaml
@@ -83,12 +83,6 @@ spec:
               args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
 {{- end }}
               env:
-{{- if .Values.env }}
-{{- range $key,$value := .Values.env }}
-              - name: {{ $key | upper | quote}}
-                value: {{ $value | quote}}
-{{- end }}
-{{- end }}
 {{- if .Values.envFromSecrets }}
 {{- range $key,$value := .Values.envFromSecrets }}
               - name: {{ $key | upper | quote}}
@@ -96,6 +90,12 @@ spec:
                   secretKeyRef:
                     name: {{ $value.from.secret | quote}}
                     key: {{ $value.from.key | quote}}
+{{- end }}
+{{- end }}
+{{- if .Values.env }}
+{{- range $key,$value := .Values.env }}
+              - name: {{ $key | upper | quote}}
+                value: {{ $value | quote}}
 {{- end }}
 {{- end }}
               resources:

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/Chart.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 2.0.0
+version: 3.0.0
 kubeVersion: ">=1.10.0-0"
 appVersion: 1.1.0
 home: https://github.com/justwatchcom/elasticsearch_exporter
@@ -16,3 +16,5 @@ maintainers:
     email: sven.mueller@commercetools.com
   - name: caarlos0
     email: carlos@carlosbecker.com
+  - name: desaintmartin
+    email: cedric@desaintmartin.fr

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/README.md
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/README.md
@@ -72,11 +72,13 @@ Parameter | Description | Default
 `service.annotations` | Annotations on the http service | `{}`
 `service.labels` | Additional labels for the service definition | `{}`
 `env` | Extra environment variables passed to pod | `{}`
+`envFromSecret` | The name of an existing secret in the same kubernetes namespace which contains values to be added to the environment | `nil`
 `secretMounts` |  list of secrets and their paths to mount inside the pod | `[]`
 `affinity` | Affinity rules | `{}`
 `es.uri` | address of the Elasticsearch node to connect to | `localhost:9200`
 `es.all` | if `true`, query stats for all nodes in the cluster, rather than just the node we connect to | `true`
 `es.indices` | if true, query stats for all indices in the cluster | `true`
+`es.indices_settings` | if true, query settings stats for all indices in the cluster | `true`
 `es.shards` | if true, query stats for shards in the cluster | `true`
 `es.cluster_settings` | if true, query stats for cluster settings | `true`
 `es.snapshots` | if true, query stats for snapshots in the cluster | `true`
@@ -99,7 +101,7 @@ Parameter | Description | Default
 `prometheusRule.enabled` | If true, a PrometheusRule CRD is created for a prometheus operator | `false`
 `prometheusRule.namespace` | If set, the PrometheusRule will be installed in a different namespace  | `""`
 `prometheusRule.labels` | Labels for prometheus operator | `{}`
-`prometheusRule.rules` | List of Prometheus rules | `[]`
+`prometheusRule.rules` | List of [PrometheusRules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example. | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -117,3 +119,15 @@ $ helm install --name my-release -f values.yaml stable/elasticsearch-exporter
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### To 3.0.0
+
+`prometheusRule.rules` are now processed as Helm template, allowing to set variables in them.
+This means that if a rule contains a {{ $value }}, Helm will try replacing it and probably fail.
+
+You now need to escape the rules (see `values.yaml`) for examples.

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/templates/deployment.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/templates/deployment.yaml
@@ -55,15 +55,25 @@ spec:
             value: "{{ $value }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
+                    {{- if .Values.es.uri }}                    
                     "--es.uri={{ .Values.es.uri }}",
+                    {{- end }}
                     {{- if .Values.es.all }}
                     "--es.all",
                     {{- end }}
                     {{- if .Values.es.indices }}
                     "--es.indices",
+                    {{- end }}
+                    {{- if .Values.es.indices_settings }}
+                    "--es.indices_settings",
                     {{- end }}
                     {{- if .Values.es.shards }}
                     "--es.shards",
@@ -110,16 +120,22 @@ spec:
               name: http
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 10
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 5
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 20"]
           volumeMounts:
             {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/templates/prometheusrule.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/templates/prometheusrule.yaml
@@ -4,21 +4,21 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}
-  {{- if .Values.prometheusRule.namespace }}
+{{- if .Values.prometheusRule.namespace }}
   namespace: {{ .Values.prometheusRule.namespace }}
-  {{- end }}
+{{- end }}
   labels:
     chart: {{ template "elasticsearch-exporter.chart" . }}
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    {{- if .Values.prometheusRule.labels }}
-    {{- toYaml .Values.prometheusRule.labels | nindent 4 }}
-    {{- end }}
+{{- if .Values.prometheusRule.labels }}
+{{- toYaml .Values.prometheusRule.labels | nindent 4 }}
+{{- end }}
 spec:
-  {{- with .Values.prometheusRule.rules }}
+{{- with .Values.prometheusRule.rules }}
   groups:
-  - name: {{ template "elasticsearch-exporter.name" $ }}
-    rules: {{- toYaml . | nindent 4 }}
-  {{- end }}
+    - name: {{ template "elasticsearch-exporter.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/values.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/values.yaml
@@ -51,7 +51,11 @@ service:
 ## env:
 ##   KEY_1: value1
 ##   KEY_2: value2
-# env:
+env: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""
 
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security
@@ -66,7 +70,7 @@ es:
   ## of a remote Elasticsearch server. When basic auth is needed,
   ## specify as: <proto>://<user>:<password>@<host>:<port>. e.g., http://admin:pass@localhost:9200.
   ##
-  uri: http://elasticsearch-master:9200
+  uri: http://localhost:9200
 
   ## If true, query stats for all nodes in the cluster, rather than just the
   ## node we connect to.
@@ -76,6 +80,10 @@ es:
   ## If true, query stats for all indices in the cluster.
   ##
   indices: true
+
+  ## If true, query settings stats for all indices in the cluster.
+  ##
+  indices_settings: true
 
   ## If true, query stats for shards in the cluster.
   ##
@@ -151,32 +159,35 @@ prometheusRule:
   ## If true, a PrometheusRule CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator
   ##
+  ## The rules will be processed as Helm template, allowing to set variables in them.
   enabled: false
   #  namespace: monitoring
   labels: {}
   rules: []
     # - record: elasticsearch_filesystem_data_used_percent
-    #   expr: 100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes)
-    #     / elasticsearch_filesystem_data_size_bytes
+    #   expr: |
+    #     100 * (elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"} - elasticsearch_filesystem_data_free_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"})
+    #     / elasticsearch_filesystem_data_size_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}"}
     # - record: elasticsearch_filesystem_data_free_percent
-    #   expr: 100 - elasticsearch_filesystem_data_used_percent
+    #   expr: 100 - elasticsearch_filesystem_data_used_percent{service="{{ template "elasticsearch-exporter.fullname" . }}"}
     # - alert: ElasticsearchTooFewNodesRunning
-    #   expr: elasticsearch_cluster_health_number_of_nodes < 3
+    #   expr: elasticsearch_cluster_health_number_of_nodes{service="{{ template "elasticsearch-exporter.fullname" . }}"} < 3
     #   for: 5m
     #   labels:
     #     severity: critical
     #   annotations:
-    #     description: There are only {{$value}} < 3 ElasticSearch nodes running
+    #     description: There are only {{ "{{ $value }}" }} < 3 ElasticSearch nodes running
     #     summary: ElasticSearch running on less than 3 nodes
     # - alert: ElasticsearchHeapTooHigh
-    #   expr: elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}
+    #   expr: |
+    #     elasticsearch_jvm_memory_used_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}", area="heap"} / elasticsearch_jvm_memory_max_bytes{service="{{ template "elasticsearch-exporter.fullname" . }}", area="heap"}
     #     > 0.9
     #   for: 15m
     #   labels:
     #     severity: critical
     #   annotations:
     #     description: The heap usage is over 90% for 15m
-    #     summary: ElasticSearch node {{$labels.node}} heap usage is high
+    #     summary: ElasticSearch node {{ "{{ $labels.node }}" }} heap usage is high
 
 # Create a service account
 # To use a service account not handled by the chart, set the name here

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/configmaps.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/configmaps.yaml
@@ -513,7 +513,7 @@ data:
     <label @NORMAL>
     <match **>
       @id elasticsearch
-      @type elasticsearch
+      @type "#{ENV['OUTPUT_TYPE']}"
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key true
       host "#{ENV['OUTPUT_HOST']}"

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
             {{- range .Values.additionalPlugins }}
             gem install {{ .name }} --version {{ .version }} &&
             {{- end }}
-            /run.sh
+            /entrypoint.sh
         {{- end }}
         env:
         - name: FLUENTD_ARGS
@@ -82,7 +82,7 @@ spec:
           {{- end }}
         - name: OUTPUT_PATH
           value: {{ .Values.elasticsearch.path | quote }}
-{{- if .Values.elasticsearch.auth.enabled }}
+{{- if and .Values.elasticsearch.auth.enabled .Values.elasticsearch.auth.user }}
         - name: OUTPUT_USER
           value: {{ .Values.elasticsearch.auth.user | quote }}
 {{- if .Values.elasticsearch.auth.password }}
@@ -98,6 +98,8 @@ spec:
           {{- else }}
           value: {{ .Values.elasticsearch.scheme | quote }}
           {{- end }}
+        - name: OUTPUT_TYPE
+          value: {{ .Values.elasticsearch.outputType | quote }}
         - name: OUTPUT_SSL_VERIFY
           value: {{ .Values.elasticsearch.sslVerify | quote }}
         - name: OUTPUT_SSL_VERSION

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/role.yaml
@@ -10,7 +10,11 @@ metadata:
     {{- end }}
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
+{{- if semverCompare "> 1.15" .Capabilities.KubeVersion.GitVersion }}
+- apiGroups: ['policy']
+{{- else }}
 - apiGroups: ['extensions']
+{{- end }}
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/servicemonitor.yaml
@@ -26,7 +26,7 @@ spec:
     relabelings:
     {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
     {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "fluentd-elasticsearch.name" . }}

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/values.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/values.yaml
@@ -3,7 +3,7 @@ image:
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
-  tag: v2.8.0
+  tag: v3.0.0
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -57,8 +57,6 @@ resources: {}
 elasticsearch:
   auth:
     enabled: false
-    user: "yourUser"
-    password: "yourPass"
   bufferChunkLimit: "2M"
   bufferQueueLimit: 8
   host: "elasticsearch-client"
@@ -68,6 +66,7 @@ elasticsearch:
   scheme: "http"
   sslVerify: true
   sslVersion: "TLSv1_2"
+  outputType: "elasticsearch"
   typeName: "_doc"
   logLevel: "info"
 
@@ -79,19 +78,19 @@ fluentdArgs: "--no-supervisor -q"
 # If you want to add custom environment variables, use the env dict
 # You can then reference these in your config file e.g.:
 #     user "#{ENV['OUTPUT_USER']}"
-env:
+env: {}
   # OUTPUT_USER: my_user
   # LIVENESS_THRESHOLD_SECONDS: 300
   # STUCK_THRESHOLD_SECONDS: 900
 
 # If you want to add custom environment variables from secrets, use the secret list
-secret:
+secret: []
 # - name: ELASTICSEARCH_PASSWORD
 #   secret_name: elasticsearch
 #   secret_key: password
 
 # If you want to add plugins at start time
-additionalPlugins:
+additionalPlugins: []
 # - name: fluent-plugin-s3
 #   version: 1.1.11
 
@@ -199,6 +198,8 @@ serviceMonitor:
   labels: {}
   metricRelabelings: []
   relabelings: []
+  jobLabel: "app.kubernetes.io/instance"
+  type: ClusterIP
 
 serviceMetric:
   ## If true, the metrics service will be created

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -51,19 +51,9 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    {{- with .Values.elasticsearch.client.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchLabels:
-                    role: client
-      {{- with .Values.elasticsearch.client.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
+{{ toYaml . | indent 8 }}
       {{- end }}
       initContainers:
       - name: init-sysctl
@@ -140,7 +130,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -177,7 +167,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -64,24 +64,15 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
-      # Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+            subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
+    {{- with .Values.elasticsearch.data.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  role: data
-      {{- with .Values.elasticsearch.data.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "opendistro-es.elasticsearch.serviceAccountName" . }}
       containers:
       - name: elasticsearch
@@ -135,6 +126,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
         {{- if .Values.elasticsearch.config }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
           name: config
@@ -148,7 +140,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-         {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -185,7 +177,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
@@ -200,13 +192,38 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
+      {{- if not .Values.elasticsearch.data.persistence.enabled }}
+      - name: "data"
+        emptyDir: {}
+      {{- else }}
+      {{- if .Values.elasticsearch.data.persistence.existingClaim }}
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ .Values.elasticsearch.data.persistence.existingClaim }}
+      {{- end }}
+      {{- end }}
+{{- if and .Values.elasticsearch.data.persistence.enabled (not .Values.elasticsearch.data.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      annotations:
+      {{- range $key, $value := .Values.elasticsearch.data.persistence.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
     spec:
-      accessModes: [ ReadWriteOnce ]
-      storageClassName: {{ .Values.elasticsearch.data.storageClassName }}
+      accessModes:
+      {{- range .Values.elasticsearch.data.persistence.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.elasticsearch.data.storage }}
+          storage: {{ .Values.elasticsearch.data.persistence.size | quote }}
+    {{- if .Values.elasticsearch.data.persistence.storageClass }}
+    {{- if (eq "-" .Values.elasticsearch.data.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.elasticsearch.data.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -54,18 +54,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      # Anti-affinity to disallow deploying client and master nodes on the same worker node
+    {{- with .Values.elasticsearch.master.affinity }}
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: "kubernetes.io/hostname"
-            labelSelector:
-              matchLabels:
-                role: master
-      {{- with .Values.elasticsearch.master.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
       initContainers:
       - name: init-sysctl
         image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
@@ -77,10 +69,11 @@ spec:
           privileged: true
       - name: fixmount
         command: [ 'sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data' ]
-        image: busybox
+        image: {{ .Values.elasticsearch.initContainer.image }}:{{ .Values.elasticsearch.initContainer.imageTag }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: data
+            subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
       containers:
       - name: elasticsearch
         env:
@@ -146,6 +139,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+          subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
         {{- if .Values.elasticsearch.config }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elasticsearch.yml
           name: config
@@ -159,7 +153,7 @@ spec:
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/logging.yml
           name: config
           subPath: logging.yml
-        {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+        {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
         - mountPath: {{ .Values.elasticsearch.configDirectory }}/elk-transport-crt.pem
           name: transport-certs
           subPath: elk-transport-crt.pem
@@ -228,7 +222,7 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
-      {{- if and .Values.elasticsearch.ssl.transport.enabled .Values.elasticsearch.ssl.transport.existingCertSecret }}
+      {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
@@ -273,13 +267,38 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.securityConfig.tenantsSecret }}
       {{- end }}
+      {{- if not .Values.elasticsearch.master.persistence.enabled }}
+      - name: "data"
+        emptyDir: {}
+      {{- else }}
+      {{- if .Values.elasticsearch.master.persistence.existingClaim }}
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ .Values.elasticsearch.master.persistence.existingClaim }}
+      {{- end }}
+      {{- end }}
+  {{- if and .Values.elasticsearch.master.persistence.enabled (not .Values.elasticsearch.master.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: data
+      annotations:
+      {{- range $key, $value := .Values.elasticsearch.master.persistence.annotations }}
+        {{ $key }}: {{ $value }}
+      {{- end }}
     spec:
-      accessModes: [ ReadWriteOnce ]
-      storageClassName: {{ .Values.elasticsearch.master.storageClassName }}
+      accessModes:
+      {{- range .Values.elasticsearch.master.persistence.accessModes }}
+        - {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.elasticsearch.master.storage }}
+          storage: {{ .Values.elasticsearch.master.persistence.size | quote }}
+    {{- if .Values.elasticsearch.master.persistence.storageClass }}
+    {{- if (eq "-" .Values.elasticsearch.master.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.elasticsearch.master.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -137,6 +137,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.elasticsearch.client.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.kibana.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/helm/efk-stack-app/charts/opendistro-es/values.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/values.yaml
@@ -12,11 +12,9 @@
 # permissions and limitations under the License.
 
 kibana:
-  # username: admin
-  # password: admin
   enabled: true
   image: amazon/opendistro-for-elasticsearch-kibana
-  imageTag: 1.2.0
+  imageTag: 1.6.0
   replicas: 1
   port: 5601
   externalPort: 443
@@ -98,6 +96,7 @@ kibana:
   ##
   tolerations: []
 
+  affinity: {}
 
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
@@ -143,7 +142,6 @@ elasticsearch:
 
   ssl:
     transport:
-      enabled: false
       existingCertSecret:
     rest:
       enabled: false
@@ -156,9 +154,36 @@ elasticsearch:
     enabled: true
     replicas: 3
     updateStrategy: "RollingUpdate"
-    nodeAffinity: {}
-    storageClassName: gp2-encrypted
-    storage: 50Gi
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## A manually managed Persistent Volume and Claim
+      ## Requires persistence.enabled: true
+      ## If defined, PVC must be created manually before volume will be bound
+      ##
+      # existingClaim:
+
+      ## The subdirectory of the volume to mount to, useful in dev environments
+      ## and one PV for multiple services.
+      ##
+      subPath: ""
+
+      ## Open Distro master Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+
     resources:
       limits:
         cpu: 1
@@ -170,7 +195,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -178,15 +202,51 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    ## Anti-affinity to disallow deploying client and master nodes on the same worker node
+    affinity: {}
+    #  podAntiAffinity:
+    #    requiredDuringSchedulingIgnoredDuringExecution:
+    #      - topologyKey: "kubernetes.io/hostname"
+    #        labelSelector:
+    #          matchLabels:
+    #            role: master
     podAnnotations: {}
 
   data:
     enabled: true
     replicas: 3
     updateStrategy: "RollingUpdate"
-    nodeAffinity: {}
-    storageClassName: gp2-encrypted
-    storage: 100Gi
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## A manually managed Persistent Volume and Claim
+      ## Requires persistence.enabled: true
+      ## If defined, PVC must be created manually before volume will be bound
+      ##
+      # existingClaim:
+
+      ## The subdirectory of the volume to mount to, useful in dev environments
+      ## and one PV for multiple services.
+      ##
+      subPath: ""
+
+      ## Open Distro master Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+
     resources:
       limits:
         cpu: 1
@@ -198,7 +258,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -206,6 +265,17 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    ## Anti-affinity to disallow deploying client and master nodes on the same worker node
+    affinity: {}
+    #  podAntiAffinity:
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        podAffinityTerm:
+    #          topologyKey: "kubernetes.io/hostname"
+    #          labelSelector:
+    #            matchLabels:
+    #              role: data
     podAnnotations: {}
 
   client:
@@ -229,9 +299,8 @@ elasticsearch:
         # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
     replicas: 2
     javaOpts: "-Xms512m -Xmx512m"
-    nodeAffinity: {}
     ingress:
-      enabled: true
+      enabled: false
       annotations: {}
         # kubernetes.io/ingress.class: nginx
         # kubernetes.io/tls-acme: "true"
@@ -253,7 +322,6 @@ elasticsearch:
     podDisruptionBudget:
       enabled: false
       minAvailable: 1
-    tolerations: []
     readinessProbe: []
     livenessProbe:
       tcpSocket:
@@ -261,6 +329,17 @@ elasticsearch:
       initialDelaySeconds: 60
       periodSeconds: 10
     nodeSelector: {}
+    tolerations: []
+    ## Weighted anti-affinity to disallow deploying client node to the same worker node as master node
+    affinity: {}
+    #  podAntiAffinity:
+    #    preferredDuringSchedulingIgnoredDuringExecution:
+    #      - weight: 1
+    #        podAffinityTerm:
+    #          topologyKey: "kubernetes.io/hostname"
+    #          labelSelector:
+    #            matchLabels:
+    #              role: client
     podAnnotations: {}
 
   config: {}
@@ -344,7 +423,7 @@ elasticsearch:
   maxMapCount: 262144
 
   image: amazon/opendistro-for-elasticsearch
-  imageTag: 1.2.0
+  imageTag: 1.6.0
 
   configDirectory: /usr/share/elasticsearch/config
 

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -45,7 +45,7 @@ elasticsearch-curator:
             epoch:
             exclude: False
     # Having config_yaml WILL override the other config
-    # Check workarround https://github.com/elastic/curator/issues/1440#issuecomment-522409936
+    # Check workaround https://github.com/elastic/curator/issues/1440#issuecomment-522409936
     config_yml: |-
       ---
       client:

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -5,6 +5,17 @@ opendistro-certs:
 
 elasticsearch-curator:
   enabled: true
+  env:
+    ELASTIC_CREDS: $(ELASTIC_USER):$(ELASTIC_PASS)
+  envFromSecrets: 
+    ELASTIC_USER:
+      from:
+        secret: kibana-auth
+        key: username
+    ELASTIC_PASS:
+      from:
+        secret: kibana-auth
+        key: password
   command: ["/usr/bin/curator"]
   image:
     repository: quay.io/giantswarm/bobrik-curator
@@ -34,13 +45,14 @@ elasticsearch-curator:
             epoch:
             exclude: False
     # Having config_yaml WILL override the other config
+    # Check workarround https://github.com/elastic/curator/issues/1440#issuecomment-522409936
     config_yml: |-
       ---
       client:
         hosts:
           - efk-stack-app-opendistro-es-client-service
         port: 9200
-        http_auth: admin:admin
+        http_auth: ${ELASTIC_CREDS}
 
 elasticsearch-exporter:
   enabled: true
@@ -52,8 +64,9 @@ elasticsearch-exporter:
       giantswarm.io/monitoring: "true"
       giantswarm.io/monitoring-path: /metrics
       giantswarm.io/monitoring-port: "9108"
+  envFromSecret: "kibana-auth"
   es:
-    uri: http://admin:admin@efk-stack-app-opendistro-es-client-service:9200
+    uri: http://$(username):$(password)@efk-stack-app-opendistro-es-client-service:9200
 
 fluentd-elasticsearch:
   enabled: true
@@ -65,7 +78,7 @@ fluentd-elasticsearch:
     enabled: true
   image:
     repository: quay.io/giantswarm/fluentd
-    tag: v2.9.0
+    tag: v3.0.0
   elasticsearch:
     host: efk-stack-app-opendistro-es-client-service
     logstashPrefix: "fluentd"
@@ -73,8 +86,15 @@ fluentd-elasticsearch:
     scheme: "http"
     auth:
       enabled: true
-      user: "admin"
-      password: "admin"
+  env:
+      LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+  secret:
+    - name: OUTPUT_USER
+      secret_name: kibana-auth
+      secret_key: username
+    - name: OUTPUT_PASSWORD
+      secret_name: kibana-auth
+      secret_key: password
 
 opendistro-es:
   enabled: true
@@ -82,7 +102,7 @@ opendistro-es:
   kibana:
     enabled: true
     image: quay.io/giantswarm/opendistro-for-elasticsearch-kibana
-    imageTag: 1.3.0
+    imageTag: 1.6.0
 
     config:
       server.name: kibana
@@ -114,8 +134,9 @@ opendistro-es:
     master:
       enabled: true
       replicas: 3
-      storageClassName: default
-      storage: 50Gi
+      persistence:
+        storageClassName: default
+        size: 50Gi
 
     initContainer:
       image: busybox
@@ -124,8 +145,9 @@ opendistro-es:
     data:
       enabled: true
       replicas: 3
-      storageClassName: default
-      storage: 100Gi
+      persistence:
+        storageClassName: default
+        size: 100Gi
 
     client:
       enabled: true
@@ -171,4 +193,4 @@ opendistro-es:
       opendistro_security.ssl.transport.pemtrustedcas_filepath: elk-transport-root-ca.pem
 
     image: quay.io/giantswarm/opendistro-for-elasticsearch
-    imageTag: 1.3.0
+    imageTag: 1.6.0

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -7,7 +7,7 @@ elasticsearch-curator:
   enabled: true
   env:
     ELASTIC_CREDS: $(ELASTIC_USER):$(ELASTIC_PASS)
-  envFromSecrets: 
+  envFromSecrets:
     ELASTIC_USER:
       from:
         secret: kibana-auth
@@ -87,7 +87,7 @@ fluentd-elasticsearch:
     auth:
       enabled: true
   env:
-      LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+    LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
   secret:
     - name: OUTPUT_USER
       secret_name: kibana-auth

--- a/manual_deploy.sh
+++ b/manual_deploy.sh
@@ -2,6 +2,6 @@
 
 kubectl create ns efk-stack-app
 
-helm template --namespace efk-stack-app --name efk-stack-app ./helm/efk-stack-app -f example_values/ingress_enabled_aws.yaml --kube-version 1.16 > deploy.yaml
+helm template --namespace efk-stack-app --name efk-stack-app ./helm/efk-stack-app -f example_values/ingress_enabled_aws_custompvc.yaml --kube-version 1.16 > deploy.yaml
 
 kubectl apply -f deploy.yaml -n efk-stack-app


### PR DESCRIPTION
## Opendistro
- Upgrade to OpenDistro 1.6.0
- Add pod affinity
- Allow subpath for Persistent Volumes
- Allow use of unmanaged Persistent Volumes
- Configurable init images

## FluentD
- Upgrade fluentD version
- Get auth from secret

## ElasticSearch Exporter
- Get auth info from secret
- `prometheusRule.rules` are now processed as Helm template, allowing to set variables in them. This means that if a rule contains a {{ $value }}, Helm will try replacing it and probably fail.

## ElasticSearch Curator
- Get auth info from secret