### PR TITLE
update to 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add release workflow
-- Helm Charts are based now on the [official repository](https://github.com/opendistro-for-elasticsearch/opendistro-build/tree/master/helm)
-- OpenDistro is upgraded to [`1.8.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.8.0.md)
 
 ### Changed
 
+- Helm Charts are based now on the [official repository](https://github.com/opendistro-for-elasticsearch/opendistro-build/tree/master/helm)
+- OpenDistro is upgraded to [`1.8.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.8.0.md)
 - Split image strings into separate values to allow for overriding of registry by chart-operator ([#15](https://github.com/giantswarm/efk-stack-app/pull/15))
 - OpenDistro is upgraded to [`1.9.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.9.0.md) ([#16](https://github.com/giantswarm/efk-stack-app/pull/16))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
+
 - Add release workflow
 - Helm Charts are based now on the [official repository](https://github.com/opendistro-for-elasticsearch/opendistro-build/tree/master/helm)
 - OpenDistro is upgraded to [`1.8.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.8.0.md)
@@ -14,6 +16,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Split image strings into separate values to allow for overriding of registry by chart-operator ([#15](https://github.com/giantswarm/efk-stack-app/pull/15))
+- OpenDistro is upgraded to [`1.9.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.9.0.md) ([#16](https://github.com/giantswarm/efk-stack-app/pull/16))
 
 ## [v0.2.0]
 ### Opendistro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Split image strings into separate values to allow for overriding of registry by chart-operator ([#15](https://github.com/giantswarm/efk-stack-app/pull/15))
 - OpenDistro is upgraded to [`1.9.0`](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/opendistro-for-elasticsearch-release-notes-1.9.0.md) ([#16](https://github.com/giantswarm/efk-stack-app/pull/16))
 
-## [v0.2.0]
+## [0.2.0] 2020-04-15
 ### Opendistro
 - Upgrade to OpenDistro 1.6.0 [Changelog](https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/release-notes/release-notes-odfe-1.6.0.md)
 - Add pod affinity
@@ -37,20 +37,19 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### ElasticSearch Curator
 - Get auth info from secret
 
-## [v0.1.5]
+## [0.1.5] 2020-02-19
 - Ignore efk-stack-app namespace in fluentd
 
-## [v0.1.4]
+## [0.1.4] 2020-02-19
 - Retagged images
 - Created changelog
 - Fixed manual deploy script
 
-## [v0.1.3]
+## [0.1.3] 2020-02-10
 - First release
 
 [Unreleased]: https://github.com/giantswarm/efk-stack-app/compare/v0.2.0...HEAD
-[v0.2.0]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.5...v0.2.0
-[v0.1.5]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.4..v0.1.5
-[v0.1.4]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.3..v0.1.4
-
-[v0.1.3]: https://github.com/giantswarm/efk-stack-app/releases/tag/v0.1.3
+[0.2.0]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.5...v0.2.0
+[0.1.5]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.4..v0.1.5
+[0.1.4]: https://github.com/giantswarm/efk-stack-app/compare/v0.1.3..v0.1.4
+[0.1.3]: https://github.com/giantswarm/efk-stack-app/releases/tag/v0.1.3

--- a/helm/efk-stack-app/Chart.yaml
+++ b/helm/efk-stack-app/Chart.yaml
@@ -24,4 +24,4 @@ name: efk-stack-app
 sources:
 - https://github.com/giantswarm/efk-stack-app
 - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v[[ .Version ]]/README.md
-version: 1.0.0
+version: [[ .Version ]]

--- a/helm/efk-stack-app/Chart.yaml
+++ b/helm/efk-stack-app/Chart.yaml
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 
 apiVersion: v1
-appVersion: 1.3.0
+appVersion: 1.9.0
 description: 'Open Distro for Elasticsearch'
 engine: gotpl
 home: https://github.com/giantswarm/efk-stack-app
@@ -24,4 +24,4 @@ name: efk-stack-app
 sources:
 - https://github.com/giantswarm/efk-stack-app
 - https://raw.githubusercontent.com/giantswarm/efk-stack-app/v[[ .Version ]]/README.md
-version: [[ .Version ]]
+version: 1.0.0

--- a/helm/efk-stack-app/charts/opendistro-es/Chart.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/Chart.yaml
@@ -13,7 +13,7 @@
 
 apiVersion: v1
 # Open Distro for Elasticsearch version
-appVersion: 1.8.0
+appVersion: 1.9.0
 description: 'Open Distro for Elasticsearch'
 engine: gotpl
 kubeVersion: ^1.10.0-0
@@ -26,4 +26,4 @@ name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
 # Chart version
-version: 1.2.0
+version: 1.9.0

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -117,6 +117,8 @@ spec:
           name: transport
         - containerPort: 9600
           name: metrics
+        - containerPort: 9650
+          name: rca
     {{- with .Values.elasticsearch.client.readinessProbe}}
         readinessProbe:
 {{ toYaml . | indent 10 }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -30,6 +30,8 @@ spec:
     name: http
   - port: 9600
     name: metrics
+  - port: 9650
+    name: rca
   clusterIP: None
   selector:
     role: data

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -145,6 +145,8 @@ spec:
           name: http
         - containerPort: 9600
           name: metrics
+        - containerPort: 9650
+          name: rca
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -32,6 +32,8 @@ spec:
       port: 9300
     - name: metrics
       port: 9600
+    - name: rca
+      port: 9650
   selector:
     role: client
   type: {{ .Values.elasticsearch.client.service.type }}

--- a/helm/efk-stack-app/charts/opendistro-es/values.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/values.yaml
@@ -16,7 +16,7 @@ kibana:
   image:
     registry: quay.io
     repository: giantswarm/opendistro-for-elasticsearch-kibana
-    tag: 1.8.0
+    tag: 1.9.0
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""
@@ -479,7 +479,7 @@ elasticsearch:
   image:
     registry: quay.io
     repository: giantswarm/opendistro-for-elasticsearch
-    tag: 1.8.0
+    tag: 1.9.0
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -112,7 +112,7 @@ opendistro-es:
     image:
       registry: quay.io
       repository: giantswarm/opendistro-for-elasticsearch-kibana
-      tag: 1.8.0@sha256:4953b3c10116218a4d0e0972dc1331ddd7001cb1c7cd490a11dd31add13ea55a
+      tag: 1.9.0@sha256:3a35a31aba8070ff7f0c215d36ad31990cabb3b04ac449d1c19943a17ddd55c4
 
     config:
       server.name: kibana
@@ -207,4 +207,4 @@ opendistro-es:
     image:
       registry: quay.io
       repository: giantswarm/opendistro-for-elasticsearch
-      tag: 1.8.0@sha256:59976249b4b8a538e7bf5baad2761ec73706ae0077eaf1dcf9a30e7ca5e6a434
+      tag: 1.9.0@sha256:878e6947b3a50487f5a57453a7ba8c1e7da6488f997c6fc257c657ad04874d29


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/12403

This PR syncs the opendistro-es subchart with upstream 1.9.0 release

https://github.com/opendistro-for-elasticsearch/opendistro-build/commit/8eef898fdc23da2e15e58248073e9900ee07a20e

I've also tidied the changelog to allow the release workflow to do its magic.
