### PR TITLE
drop release and heritage label selectors

### DIFF
--- a/helm/efk-stack-app/charts/opendistro-es/templates/_helpers.tpl
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/_helpers.tpl
@@ -53,11 +53,11 @@ heritage: "{{ .Release.Service }}"
 {{/*
 Define labels for deployment/statefulset selectors.
 We cannot have the chart label here as it will prevent upgrades.
+
+If these labels are changed then upgrades will fail as label selectors are immutable.
 */}}
 {{- define "opendistro-es.labels.selector" -}}
 app: {{ template "opendistro-es.fullname" . }}
-release: "{{ .Release.Name }}"
-heritage: "{{ .Release.Service }}"
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
These were added in #10, but they will prevent upgrades from older releases.
