### PR TITLE
Don't template ES client URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set `es-client` URI to a static value to avoid issues when templating across multiple subcharts. ([#24](https://github.com/giantswarm/efk-stack-app/pull/24))
+
 ## [0.3.2] - 2020-09-15
 
 ### Changed

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/templates/deployment.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["elasticsearch_exporter",
                     {{- if .Values.es.uri }}
-                    "--es.uri={{ .Values.es.uri }}",
+                    "--es.uri=http://$(username):$(password)@{{ .Values.global.opendistro.es.client.uri }}:9200",
                     {{- end }}
                     {{- if .Values.es.all }}
                     "--es.all",

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-service.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-service.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
     role: client
-  name: {{ template "opendistro-es.fullname" . }}-client-service
+  name: {{ .Values.global.opendistro.es.client.uri }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:

--- a/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         # If no custom configuration provided, default to internal DNS
         {{- if not .Values.kibana.config }}
         - name: ELASTICSEARCH_HOSTS
-          value: https://{{ template "opendistro-es.fullname" . }}-client-service:9200
+          value: https://{{ .Values.global.opendistro.es.client.uri }}:9200
         {{- end }}
         {{- if .Values.kibana.elasticsearchAccount.secret }}
         - name: ELASTICSEARCH_USERNAME

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -60,7 +60,7 @@ elasticsearch-curator:
       ---
       client:
         hosts:
-          - efk-stack-app-opendistro-es-client-service
+          - opendistro-es-client-service
         port: 9200
         http_auth: ${ELASTIC_CREDS}
 
@@ -77,7 +77,7 @@ elasticsearch-exporter:
       giantswarm.io/monitoring-port: "9108"
   envFromSecret: "kibana-auth"
   es:
-    uri: http://$(username):$(password)@efk-stack-app-opendistro-es-client-service:9200
+    uri: http://$(username):$(password)@opendistro-es-client-service:9200
 
 fluentd-elasticsearch:
   enabled: true
@@ -92,7 +92,7 @@ fluentd-elasticsearch:
     repository: giantswarm/fluentd
     tag: v3.0.0@sha256:2cc9334d646b14a002e71f0b0c34eca411e35f07c88f0bac9783805fb13c0190
   elasticsearch:
-    host: efk-stack-app-opendistro-es-client-service
+    host: opendistro-es-client-service
     logstashPrefix: "fluentd"
     sslVerify: false
     scheme: "http"
@@ -122,7 +122,7 @@ opendistro-es:
       server.name: kibana
       server.host: "0"
 
-      elasticsearch.hosts: http://efk-stack-app-opendistro-es-client-service:9200
+      elasticsearch.hosts: http://opendistro-es-client-service:9200
       elasticsearch.requestTimeout: 360000
 
       logging.verbose: false

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -1,6 +1,10 @@
 global:
   image:
     registry: quay.io
+  opendistro:
+    es:
+      client:
+        uri: opendistro-es-client-service
 
 opendistro-certs:
   enabled: true


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/12209

This PR:

- sets the es-client svc uri to a static value.

#### Rationale

It is impossible to template the URI, due to two factors:

1. it must be used in several different subcharts, and therefore templating will render the name differently each time.
2. it is used it multiple places in the root `values.yaml`, and this file cannot contain templated values.

### Checklist

- [x] Update changelog in CHANGELOG.md.

