### PR TITLE
enable antiAffinity and PDBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- enabled antiAffinity to spread `master`, `data` and `client` nodes across `hostname`s
+- enabled PDBs for `master` and `data`: `minAvailable=66%` and for `client`: `minavailable=1`
+
 ## [0.3.3] - 2020-10-22
 
 ### Changed

--- a/helm/efk-stack-app/charts/opendistro-es/values.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/values.yaml
@@ -257,13 +257,13 @@ elasticsearch:
     nodeSelector: {}
     tolerations: []
     ## Anti-affinity to disallow deploying client and master nodes on the same worker node
-    affinity: {}
-    #  podAntiAffinity:
-    #    requiredDuringSchedulingIgnoredDuringExecution:
-    #      - topologyKey: "kubernetes.io/hostname"
-    #        labelSelector:
-    #          matchLabels:
-    #            role: master
+    affinity: # {}
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                role: master
     podAnnotations: {}
 
   data:
@@ -320,15 +320,15 @@ elasticsearch:
     nodeSelector: {}
     tolerations: []
     ## Anti-affinity to disallow deploying client and master nodes on the same worker node
-    affinity: {}
-    #  podAntiAffinity:
-    #    preferredDuringSchedulingIgnoredDuringExecution:
-    #      - weight: 1
-    #        podAffinityTerm:
-    #          topologyKey: "kubernetes.io/hostname"
-    #          labelSelector:
-    #            matchLabels:
-    #              role: data
+    affinity: # {}
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  role: data
     podAnnotations: {}
 
   client:
@@ -388,15 +388,15 @@ elasticsearch:
     nodeSelector: {}
     tolerations: []
     ## Weighted anti-affinity to disallow deploying client node to the same worker node as master node
-    affinity: {}
-    #  podAntiAffinity:
-    #    preferredDuringSchedulingIgnoredDuringExecution:
-    #      - weight: 1
-    #        podAffinityTerm:
-    #          topologyKey: "kubernetes.io/hostname"
-    #          labelSelector:
-    #            matchLabels:
-    #              role: client
+    affinity: # {}
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  role: client
     podAnnotations: {}
 
   config: {}

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -145,12 +145,19 @@ opendistro-es:
       secret: kibana-auth
 
   elasticsearch:
+    sysctl:
+      enabled: true
+
     master:
       enabled: true
       replicas: 3
       persistence:
         storageClassName: default
         size: 50Gi
+      podDisruptionBudget:
+        enabled: true
+        # should work for 1,3,5 replicas in master group
+        minAvailable: 66%
 
     initContainer:
       image:
@@ -164,10 +171,16 @@ opendistro-es:
       persistence:
         storageClassName: default
         size: 100Gi
+      podDisruptionBudget:
+        enabled: true
+        # should work for 1,3,5 replicas in master group
+        minAvailable: 66%
 
     client:
       enabled: true
       ingress:
+        enabled: false
+      podDisruptionBudget:
         enabled: false
 
     ssl:


### PR DESCRIPTION
This PR:

- enables antiAffinity to spread `master`, `data` and `client` nodes across `hostname`s
- enables PDBs for `master` and `data`: `minAvailable=66%` and for `client`: `minavailable=1`
