### PR TITLE
Override Kibana Image Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add overridability of the Kibana image registry to allow users to ues their own image (extra-plugins, etc.).
+
 ## [0.5.2] - 2021-05-14
 
 ### Fixed

--- a/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/kibana/kibana-deployment.yaml
@@ -84,7 +84,11 @@ spec:
 {{- if .Values.kibana.extraEnvs }}
 {{ toYaml .Values.kibana.extraEnvs | indent 8 }}
 {{- end }}
+        {{- if .Values.kibana.registry }}
+        image: {{ .Values.kibana.registry }}/{{ .Values.kibana.image }}:{{ .Values.kibana.imageTag }}
+        {{- else }}
         image: {{ .Values.global.imageRegistry }}/{{ .Values.kibana.image }}:{{ .Values.kibana.imageTag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.kibana.imagePullPolicy | default "Always" | quote }}
     {{- with .Values.kibana.readinessProbe}}
         readinessProbe:

--- a/helm/efk-stack-app/charts/opendistro-es/values.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/values.yaml
@@ -13,6 +13,8 @@
 
 kibana:
   enabled: true
+  # Allows override of the registry for the kibana image only
+  registry: ""
   image: amazon/opendistro-for-elasticsearch-kibana
   imageTag: 1.13.2
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".

--- a/helm/efk-stack-app/values.yaml
+++ b/helm/efk-stack-app/values.yaml
@@ -123,6 +123,8 @@ opendistro-es:
 
   kibana:
     enabled: true
+    # Allows override of the registry for the kibana image only
+    registry: ""
     # see https://quay.io/repository/giantswarm/opendistro-for-elasticsearch-kibana?tab=tags
     image: giantswarm/opendistro-for-elasticsearch-kibana
     imageTag: 1.13.2@sha256:c740d7a89475518b07f52809f264e55f235d9c6432c60a1bf2e703376e55c835


### PR DESCRIPTION
<!--
@app-squad-efk will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- adds support to override the kibana image registry to allow customer to provide their own to install plugins, set default configs and so on

### Checklist

- [x] Update changelog in CHANGELOG.md.

