### PR TITLE
set elasticsearch (master & data) service type to ClusterIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Fix incorrect internal service name for `efk-stack-app-opendistro-es-client-service`.
+- Set elasticsearch master and data service type to `ClusterIP`.
 
 ## [0.6.0] - 2021-10-15
 

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-svc.yaml
@@ -35,10 +35,10 @@ spec:
     name: metrics
   - port: 9650
     name: rca
-  clusterIP: None
   selector:
   {{- if .Values.elasticsearch.data.dedicatedPod.enabled }}
     role: data
   {{- else }}
     role: master
   {{- end }}
+  type: ClusterIP

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/master-svc.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/master-svc.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
     - port: 9300
       protocol: TCP
-  clusterIP: None
   selector:
     role: master
+  type: ClusterIP
 {{- end }}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#19393

This PR fixes service type for both elasticsearch master and data services.

Otherwise those service are never assigned an IP address.

controller-manager logs
```
I1201 00:41:03.330799       1 utils.go:413] couldn't find ipfamilies for service: kube-system/node-exporter. This could happen if controller manager is connected to an old apiserver that does not support ip famili
es yet. EndpointSlices for this Service will use IPv4 as the IP Family based on familyOf(ClusterIP:172.31.122.125).
I1201 00:41:03.330871       1 utils.go:424] couldn't find ipfamilies for headless service: efk-stack-app/efk-stack-app-opendistro-es-discovery likely because controller manager is likely connected to an old apiser
ver that does not support ip families yet. The service endpoint slice will use dual stack families until api-server default it correctly
```

```
$ k get svc
NAME                                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
efk-stack-app-elasticsearch-exporter         ClusterIP   172.31.52.105    <none>        9108/TCP                              37m
efk-stack-app-opendistro-es-client-service   ClusterIP   172.31.254.88    <none>        9200/TCP,9300/TCP,9600/TCP,9650/TCP   37m
efk-stack-app-opendistro-es-data-svc         ClusterIP   None             <none>        9300/TCP,9200/TCP,9600/TCP,9650/TCP   37m
efk-stack-app-opendistro-es-discovery        ClusterIP   None             <none>        9300/TCP                              37m
efk-stack-app-opendistro-es-kibana-svc       ClusterIP   172.31.172.189   <none>        443/TCP                               37m
```