### PR TITLE
increase curator log level to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Print deleted files when cleaning leftover lock files on NFS storage.
 - Remove duplicate service for elasticsearch ingest nodes.
 - Increase log level for fluentd.
+- Increase log level for curator.
 
 ### Fixed
 

--- a/helm/efk-stack-app/charts/elasticsearch-curator/values.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-curator/values.yaml
@@ -85,8 +85,8 @@ configMaps:
       # http_auth:
       # timeout: 30
       # master_only: False
-    # logging:
-    #   loglevel: INFO
+    logging:
+      loglevel: DEBUG
     #   logfile:
     #   logformat: default
     #   blacklist: ['elasticsearch', 'urllib3']


### PR DESCRIPTION
Towards: giantswarm/giantswarm#19393

This PR increase curator log level to debug. Since this cronjob runs once a day, having a bit of extra log is not a problem but help in case things go wrong.

Previous INFO log level shows:

```
$ k logs -f curator-1-56d2z
2021-12-01 11:31:35,259 INFO      Preparing Action ID: 1, "delete_indices"
2021-12-01 11:31:35,259 INFO      Creating client object and testing connection
2021-12-01 11:31:35,262 INFO      Instantiating client object
2021-12-01 11:31:35,262 INFO      Testing client connectivity
2021-12-01 11:31:35,270 INFO      Successfully created Elasticsearch client object with provided settings
2021-12-01 11:31:35,273 INFO      Trying Action ID: 1, "delete_indices": Clean up ES by deleting old indices
2021-12-01 11:31:35,311 INFO      Skipping action "delete_indices" due to empty list: <class 'curator.exceptions.NoIndices'>
2021-12-01 11:31:35,311 INFO      Action ID: 1, "delete_indices" completed.
```

New DEBUG log level shows:

```
$ k logs -f curator-2-cb5rr
2021-12-01 11:40:08,723 DEBUG                curator.cli                    run:110  Client and logging options validated.
2021-12-01 11:40:08,723 DEBUG                curator.cli                    run:114  default_timeout = 30
2021-12-01 11:40:08,723 DEBUG                curator.cli                    run:118  action_file: /etc/es-curator/action_file.yml
2021-12-01 11:40:08,728 DEBUG                curator.cli                    run:120  action_config: {'actions': {1: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': None, 'field': None, 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}], 'options': {'continue_if_exception': False, 'timeout_override': None, 'ignore_empty_list': True, 'disable_action': False}}}}
2021-12-01 11:40:08,728 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'actions': <type 'dict'>}
2021-12-01 11:40:08,728 DEBUG     curator.validators.SchemaCheck               __init__:27   "Actions File" config: {'actions': {1: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': None, 'source': 'name', 'filtertype': 'age', 'field': None, 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}], 'options': {'continue_if_exception': False, 'timeout_override': None, 'ignore_empty_list': True, 'disable_action': False}}}}
2021-12-01 11:40:08,728 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'action': Any(In(['alias', 'allocation', 'close', 'cluster_routing', 'create_index', 'delete_indices', 'delete_snapshots', 'forcemerge', 'freeze', 'index_settings', 'open', 'reindex', 'replicas', 'restore', 'rollover', 'shrink', 'snapshot', 'unfreeze']), msg="action must be one of ['alias', 'allocation', 'close', 'cluster_routing', 'create_index', 'delete_indices', 'delete_snapshots', 'forcemerge', 'freeze', 'index_settings', 'open', 'reindex', 'replicas', 'restore', 'rollover', 'shrink', 'snapshot', 'unfreeze']")}
2021-12-01 11:40:08,729 DEBUG     curator.validators.SchemaCheck               __init__:27   "action type" config: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': None, 'source': 'name', 'filtertype': 'age', 'field': None, 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}], 'options': {'continue_if_exception': False, 'timeout_override': None, 'ignore_empty_list': True, 'disable_action': False}}
2021-12-01 11:40:08,729 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'action': Any(In(['alias', 'allocation', 'close', 'cluster_routing', 'create_index', 'delete_indices', 'delete_snapshots', 'forcemerge', 'freeze', 'index_settings', 'open', 'reindex', 'replicas', 'restore', 'rollover', 'shrink', 'snapshot', 'unfreeze']), msg="action must be one of ['alias', 'allocation', 'close', 'cluster_routing', 'create_index', 'delete_indices', 'delete_snapshots', 'forcemerge', 'freeze', 'index_settings', 'open', 'reindex', 'replicas', 'restore', 'rollover', 'shrink', 'snapshot', 'unfreeze']"), 'description': Any(<type 'str'>, <type 'basestring'>, msg=None), 'filters': <type 'list'>, 'options': <type 'dict'>}
2021-12-01 11:40:08,729 DEBUG     curator.validators.SchemaCheck               __init__:27   "structure" config: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': None, 'source': 'name', 'filtertype': 'age', 'field': None, 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}], 'options': {'continue_if_exception': False, 'timeout_override': None, 'ignore_empty_list': True, 'disable_action': False}}
2021-12-01 11:40:08,733 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'continue_if_exception': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb2420c8>, msg=None), msg=None), 'allow_ilm_indices': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb2425f0>, msg=None), msg=None), 'timeout_override': Any(Coerce(int, msg=None), None, msg=None), 'ignore_empty_list': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb242b90>, msg=None), msg=None), 'disable_action': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb242a28>, msg=None), msg=None)}
2021-12-01 11:40:08,733 DEBUG     curator.validators.SchemaCheck               __init__:27   "options" config: {'continue_if_exception': False, 'ignore_empty_list': True, 'disable_action': False}
2021-12-01 11:40:08,733 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: <function f at 0x7fd8fb2421b8>
2021-12-01 11:40:08,734 DEBUG     curator.validators.SchemaCheck               __init__:27   "filters" config: [{'direction': 'older', 'stats_result': None, 'source': 'name', 'filtertype': 'age', 'field': None, 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}]
2021-12-01 11:40:08,734 DEBUG     curator.defaults.filtertypes                    age:55   AGE FILTER = [{'direction': Any('older', 'younger', msg=None)}, {'unit': Any('seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years', msg=None)}, {'unit_count': Coerce(int, msg=None)}, {'unit_count_pattern': Any(<type 'basestring'>, msg=None)}, {'epoch': Any(Coerce(int, msg=None), None, msg=None)}, {'exclude': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb242ed8>, msg=None), msg=None)}, {'source': Any('name', 'creation_date', 'field_stats', msg=None)}, {'stats_result': Any('min_value', 'max_value', msg=None)}, {'timestring': Any(<type 'basestring'>, msg=None)}]
2021-12-01 11:40:08,734 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'source': Any('name', 'creation_date', 'field_stats', msg=None), 'direction': Any('older', 'younger', msg=None), 'stats_result': Any('min_value', 'max_value', msg=None), 'timestring': Any(<type 'basestring'>, msg=None), 'exclude': Any(<type 'bool'>, All(Any(<type 'basestring'>, msg=None), <function Boolean at 0x7fd8fb242ed8>, msg=None), msg=None), 'filtertype': Any(In(['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']), msg="filtertype must be one of ['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']"), 'unit_count': Coerce(int, msg=None), 'epoch': Any(Coerce(int, msg=None), None, msg=None), 'unit': Any('seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years', msg=None), 'unit_count_pattern': Any(<type 'basestring'>, msg=None)}
2021-12-01 11:40:08,735 DEBUG     curator.validators.SchemaCheck               __init__:27   "filter" config: {'direction': 'older', 'filtertype': 'age', 'source': 'name', 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,735 DEBUG     curator.validators.filters                      f:48   Filter #0: {'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:123  Full list of actions: {1: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}], 'options': {'continue_if_exception': False, 'allow_ilm_indices': False, 'timeout_override': None, 'ignore_empty_list': True, 'disable_action': False}}}
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:128  action_disabled = False
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:132  continue_if_exception = False
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:134  timeout_override = None
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:136  ignore_empty_list = True
2021-12-01 11:40:08,735 DEBUG                curator.cli                    run:138  allow_ilm_indices = False
2021-12-01 11:40:08,735 INFO                 curator.cli                    run:148  Preparing Action ID: 1, "delete_indices"
2021-12-01 11:40:08,736 INFO                 curator.cli                    run:162  Creating client object and testing connection
2021-12-01 11:40:08,736 DEBUG              curator.utils             get_client:809  kwargs = {'url_prefix': '', 'aws_secret_key': None, 'http_auth': 'admin:admin', 'certificate': None, 'aws_key': None, 'aws_sign_request': False, 'port': 9200, 'hosts': ['opendistro-es-client-service'], 'timeout': 30, 'aws_token': None, 'use_ssl': False, 'master_only': False, 'client_cert': None, 'ssl_no_validate': False, 'client_key': None}
2021-12-01 11:40:08,736 DEBUG              curator.utils             get_client:871  Checking for AWS settings
2021-12-01 11:40:08,739 DEBUG              curator.utils             get_client:886  "requests_aws4auth" module present, but not used.
2021-12-01 11:40:08,739 INFO               curator.utils             get_client:903  Instantiating client object
2021-12-01 11:40:08,739 INFO               curator.utils             get_client:906  Testing client connectivity
2021-12-01 11:40:08,745 DEBUG              curator.utils             get_client:907  Cluster info: {u'cluster_name': u'elasticsearch', u'cluster_uuid': u'zCdvvRomQAy4OiAF58k4jA', u'version': {u'build_date': u'2021-01-13T00:42:12.435326Z', u'minimum_wire_compatibility_version': u'6.8.0', u'build_hash': u'747e1cc71def077253878a59143c1f785afa92b9', u'number': u'7.10.2', u'lucene_version': u'8.7.0', u'minimum_index_compatibility_version': u'6.0.0-beta1', u'build_flavor': u'oss', u'build_snapshot': False, u'build_type': u'tar'}, u'name': u'efk-stack-app-opendistro-es-client-cf56cc965-fm4lq', u'tagline': u'You Know, for Search'}
2021-12-01 11:40:08,745 INFO               curator.utils             get_client:908  Successfully created Elasticsearch client object with provided settings
2021-12-01 11:40:08,745 DEBUG              curator.utils             get_client:932  Checking Elasticsearch endpoint version...
2021-12-01 11:40:08,748 DEBUG              curator.utils          check_version:693  Detected Elasticsearch version 7.10.2
2021-12-01 11:40:08,748 DEBUG              curator.utils             get_client:951  Not verifying local master status (master_only: false)
2021-12-01 11:40:08,748 INFO                 curator.cli                    run:194  Trying Action ID: 1, "delete_indices": Clean up ES by deleting old indices
2021-12-01 11:40:08,748 DEBUG                curator.cli         process_action:46   Configuration dictionary: {'action': 'delete_indices', 'description': 'Clean up ES by deleting old indices', 'filters': [{'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}, {'filtertype': 'ilm'}], 'options': {}}
2021-12-01 11:40:08,748 DEBUG                curator.cli         process_action:47   kwargs: {'master_timeout': 30, 'dry_run': False}
2021-12-01 11:40:08,748 DEBUG                curator.cli         process_action:52   opts: {}
2021-12-01 11:40:08,748 DEBUG                curator.cli         process_action:64   Action kwargs: {'master_timeout': 30}
2021-12-01 11:40:08,749 DEBUG                curator.cli         process_action:93   Running "DELETE_INDICES"
2021-12-01 11:40:08,749 DEBUG          curator.indexlist          __get_indices:65   Getting all indices
2021-12-01 11:40:08,757 DEBUG              curator.utils            get_indices:648  Detected Elasticsearch version 7.10.2
2021-12-01 11:40:08,757 DEBUG              curator.utils            get_indices:650  All indices: [u'.opendistro_security', u'security-auditlog-2021.12.01', u'.kibana_1', u'security-auditlog-2021.11.30']
2021-12-01 11:40:08,757 DEBUG          curator.indexlist     __build_index_info:80   Building preliminary index metadata for .opendistro_security
2021-12-01 11:40:08,757 DEBUG          curator.indexlist     __build_index_info:80   Building preliminary index metadata for security-auditlog-2021.12.01
2021-12-01 11:40:08,757 DEBUG          curator.indexlist     __build_index_info:80   Building preliminary index metadata for .kibana_1
2021-12-01 11:40:08,757 DEBUG          curator.indexlist     __build_index_info:80   Building preliminary index metadata for security-auditlog-2021.11.30
2021-12-01 11:40:08,758 DEBUG          curator.indexlist          _get_metadata:177  Getting index metadata
2021-12-01 11:40:08,758 DEBUG          curator.indexlist       empty_list_check:226  Checking for empty list
2021-12-01 11:40:08,775 DEBUG          curator.indexlist       _get_index_stats:117  Getting index stats
2021-12-01 11:40:08,775 DEBUG          curator.indexlist       empty_list_check:226  Checking for empty list
2021-12-01 11:40:08,775 DEBUG          curator.indexlist           working_list:237  Generating working list of indices
2021-12-01 11:40:08,775 DEBUG          curator.indexlist           working_list:237  Generating working list of indices
2021-12-01 11:40:08,784 DEBUG          curator.indexlist     iterate_over_stats:126  Index: security-auditlog-2021.12.01  Size: 299.3KB  Docs: 18
2021-12-01 11:40:08,784 DEBUG          curator.indexlist     iterate_over_stats:126  Index: .opendistro_security  Size: 171.0KB  Docs: 27
2021-12-01 11:40:08,784 DEBUG          curator.indexlist     iterate_over_stats:126  Index: .kibana_1  Size: 39.6KB  Docs: 18
2021-12-01 11:40:08,784 DEBUG          curator.indexlist     iterate_over_stats:126  Index: security-auditlog-2021.11.30  Size: 445.0KB  Docs: 56
2021-12-01 11:40:08,784 DEBUG          curator.indexlist        iterate_filters:1218 Iterating over a list of filters
2021-12-01 11:40:08,784 DEBUG          curator.indexlist        iterate_filters:1224 All filters: [{'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}, {'filtertype': 'ilm'}]
2021-12-01 11:40:08,785 DEBUG          curator.indexlist        iterate_filters:1226 Top of the loop: [u'.opendistro_security', u'security-auditlog-2021.12.01', u'.kibana_1', u'security-auditlog-2021.11.30']
2021-12-01 11:40:08,785 DEBUG          curator.indexlist        iterate_filters:1227 Un-parsed filter args: {'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,787 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'threshold_behavior': Any(<type 'basestring'>, msg=None), 'direction': Any(<type 'basestring'>, msg=None), 'shard_filter_behavior': Any(<type 'basestring'>, msg=None), 'intersect': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'number_of_shards': Coerce(int, msg=None), 'week_starts_on': Any(None, <type 'basestring'>, msg=None), 'range_from': Coerce(int, msg=None), 'key': Any(<type 'basestring'>, msg=None), 'date_to': Any(None, <type 'basestring'>, msg=None), 'max_num_segments': Coerce(int, msg=None), 'exclude': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'disk_space': <type 'float'>, 'date_from_format': Any(None, <type 'basestring'>, msg=None), 'unit': Any(<type 'basestring'>, msg=None), 'aliases': Any(<type 'list'>, <type 'basestring'>, msg=None), 'count': Coerce(int, msg=None), 'kind': Any(<type 'basestring'>, msg=None), 'stats_result': Any(None, <type 'basestring'>, msg=None), 'reverse': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'source': Any(<type 'basestring'>, msg=None), 'pattern': Any(<type 'basestring'>, msg=None), 'date_from': Any(None, <type 'basestring'>, msg=None), 'filtertype': Any(In(['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']), msg="filtertype must be one of ['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']"), 'state': Any(<type 'basestring'>, msg=None), 'value': Any(<type 'int'>, <type 'float'>, <type 'bool'>, <type 'basestring'>, msg=None), 'unit_count_pattern': Any(<type 'basestring'>, msg=None), 'date_to_format': Any(None, <type 'basestring'>, msg=None), 'field': Any(None, <type 'basestring'>, msg=None), 'epoch': Any(Coerce(int, msg=None), None, msg=None), 'period_type': Any(<type 'basestring'>, msg=None), 'allocation_type': Any(<type 'basestring'>, msg=None), 'range_to': Coerce(int, msg=None), 'timestring': Any(None, <type 'basestring'>, msg=None), 'unit_count': Coerce(int, msg=None), 'use_age': <function Boolean at 0x7fd8fb1dca28>}
2021-12-01 11:40:08,788 DEBUG     curator.validators.SchemaCheck               __init__:27   "filter" config: {'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,788 DEBUG          curator.indexlist        iterate_filters:1234 Parsed filter args: {'direction': 'older', 'stats_result': 'min_value', 'filtertype': 'age', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,788 DEBUG          curator.indexlist        iterate_filters:1243 Filter args: {'direction': 'older', 'stats_result': 'min_value', 'source': 'name', 'epoch': None, 'timestring': '%Y.%m.%d', 'exclude': False, 'unit_count': 7, 'unit': 'days'}
2021-12-01 11:40:08,788 DEBUG          curator.indexlist        iterate_filters:1244 Pre-instance: [u'.opendistro_security', u'security-auditlog-2021.12.01', u'.kibana_1', u'security-auditlog-2021.11.30']
2021-12-01 11:40:08,788 DEBUG          curator.indexlist          filter_by_age:490  Filtering indices by age
2021-12-01 11:40:08,789 DEBUG          curator.indexlist   _get_name_based_ages:280  Getting ages of indices by "name"
2021-12-01 11:40:08,789 DEBUG          curator.indexlist       empty_list_check:226  Checking for empty list
2021-12-01 11:40:08,789 DEBUG              curator.utils         get_date_regex:200  regex = \d{4}\.\d{2}\.\d{2}
2021-12-01 11:40:08,789 DEBUG          curator.indexlist           working_list:237  Generating working list of indices
2021-12-01 11:40:08,792 DEBUG          curator.indexlist           working_list:237  Generating working list of indices
2021-12-01 11:40:08,792 DEBUG          curator.indexlist          filter_by_age:552  Index ".opendistro_security" does not meet provided criteria. Removing from list.
2021-12-01 11:40:08,793 DEBUG          curator.indexlist       __not_actionable:39   Index security-auditlog-2021.12.01 is not actionable, removing from list.
2021-12-01 11:40:08,793 DEBUG          curator.indexlist            __excludify:58   Removed from actionable list: Index "security-auditlog-2021.12.01" age (1638316800), direction: "older", point of reference, (1637754008)
2021-12-01 11:40:08,793 DEBUG          curator.indexlist          filter_by_age:552  Index ".kibana_1" does not meet provided criteria. Removing from list.
2021-12-01 11:40:08,793 DEBUG          curator.indexlist       __not_actionable:39   Index security-auditlog-2021.11.30 is not actionable, removing from list.
2021-12-01 11:40:08,793 DEBUG          curator.indexlist            __excludify:58   Removed from actionable list: Index "security-auditlog-2021.11.30" age (1638230400), direction: "older", point of reference, (1637754008)
2021-12-01 11:40:08,793 DEBUG          curator.indexlist        iterate_filters:1246 Post-instance: []
2021-12-01 11:40:08,793 DEBUG          curator.indexlist        iterate_filters:1226 Top of the loop: []
2021-12-01 11:40:08,793 DEBUG          curator.indexlist        iterate_filters:1227 Un-parsed filter args: {'filtertype': 'ilm'}
2021-12-01 11:40:08,795 DEBUG     curator.validators.SchemaCheck               __init__:26   Schema: {'threshold_behavior': Any(<type 'basestring'>, msg=None), 'direction': Any(<type 'basestring'>, msg=None), 'shard_filter_behavior': Any(<type 'basestring'>, msg=None), 'intersect': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'number_of_shards': Coerce(int, msg=None), 'week_starts_on': Any(None, <type 'basestring'>, msg=None), 'range_from': Coerce(int, msg=None), 'key': Any(<type 'basestring'>, msg=None), 'date_to': Any(None, <type 'basestring'>, msg=None), 'max_num_segments': Coerce(int, msg=None), 'exclude': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'disk_space': <type 'float'>, 'date_from_format': Any(None, <type 'basestring'>, msg=None), 'unit': Any(<type 'basestring'>, msg=None), 'aliases': Any(<type 'list'>, <type 'basestring'>, msg=None), 'count': Coerce(int, msg=None), 'kind': Any(<type 'basestring'>, msg=None), 'stats_result': Any(None, <type 'basestring'>, msg=None), 'reverse': Any(None, <type 'bool'>, <type 'int'>, <type 'basestring'>, msg=None), 'source': Any(<type 'basestring'>, msg=None), 'pattern': Any(<type 'basestring'>, msg=None), 'date_from': Any(None, <type 'basestring'>, msg=None), 'filtertype': Any(In(['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']), msg="filtertype must be one of ['age', 'alias', 'allocated', 'closed', 'count', 'empty', 'forcemerged', 'ilm', 'kibana', 'none', 'opened', 'pattern', 'period', 'shards', 'space', 'state']"), 'state': Any(<type 'basestring'>, msg=None), 'value': Any(<type 'int'>, <type 'float'>, <type 'bool'>, <type 'basestring'>, msg=None), 'unit_count_pattern': Any(<type 'basestring'>, msg=None), 'date_to_format': Any(None, <type 'basestring'>, msg=None), 'field': Any(None, <type 'basestring'>, msg=None), 'epoch': Any(Coerce(int, msg=None), None, msg=None), 'period_type': Any(<type 'basestring'>, msg=None), 'allocation_type': Any(<type 'basestring'>, msg=None), 'range_to': Coerce(int, msg=None), 'timestring': Any(None, <type 'basestring'>, msg=None), 'unit_count': Coerce(int, msg=None), 'use_age': <function Boolean at 0x7fd8fb1ceb90>}
2021-12-01 11:40:08,795 DEBUG     curator.validators.SchemaCheck               __init__:27   "filter" config: {'filtertype': 'ilm'}
2021-12-01 11:40:08,795 DEBUG          curator.indexlist        iterate_filters:1234 Parsed filter args: {'filtertype': 'ilm'}
2021-12-01 11:40:08,795 DEBUG          curator.indexlist             filter_ilm:1180 Filtering indices with index.lifecycle.name
2021-12-01 11:40:08,795 DEBUG          curator.indexlist             filter_ilm:1183 Empty working list. No ILM indices to filter.
2021-12-01 11:40:08,796 DEBUG     curator.actions.delete_indices               __init__:593  master_timeout value: 30s
2021-12-01 11:40:08,796 DEBUG                curator.cli         process_action:101  Doing the action here.
2021-12-01 11:40:08,796 DEBUG          curator.indexlist       empty_list_check:226  Checking for empty list
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:202  Skipping action "delete_indices" due to empty list: <class 'curator.exceptions.NoIndices'>
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:223  Action ID: 1, "delete_indices" completed.
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:224  Job completed.
```

And it's easy to grep by `INFO`
```
$ k logs curator-2-cb5rr|grep 'INFO'
2021-12-01 11:40:08,735 INFO                 curator.cli                    run:148  Preparing Action ID: 1, "delete_indices"
2021-12-01 11:40:08,736 INFO                 curator.cli                    run:162  Creating client object and testing connection
2021-12-01 11:40:08,739 INFO               curator.utils             get_client:903  Instantiating client object
2021-12-01 11:40:08,739 INFO               curator.utils             get_client:906  Testing client connectivity
2021-12-01 11:40:08,745 INFO               curator.utils             get_client:908  Successfully created Elasticsearch client object with provided settings
2021-12-01 11:40:08,748 INFO                 curator.cli                    run:194  Trying Action ID: 1, "delete_indices": Clean up ES by deleting old indices
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:202  Skipping action "delete_indices" due to empty list: <class 'curator.exceptions.NoIndices'>
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:223  Action ID: 1, "delete_indices" completed.
2021-12-01 11:40:08,796 INFO                 curator.cli                    run:224  Job completed.
```