### PR TITLE
fix config files permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Fix incorrect internal service name for `efk-stack-app-opendistro-es-client-service`.
 - Set elasticsearch master and data service type to `ClusterIP`.
+- Set config files permissions to `0600`.
 
 ## [0.6.0] - 2021-10-15
 

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -192,20 +192,24 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
+          defaultMode: 0600
       {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
       - name: rest-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
       - name: admin-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
 {{- if .Values.elasticsearch.extraVolumes }}
 {{ toYaml .Values.elasticsearch.extraVolumes | indent 6 }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -216,20 +216,24 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
+          defaultMode: 0600
       {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
       - name: rest-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
       - name: admin-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if not .Values.elasticsearch.data.persistence.enabled }}
       - name: "data"

--- a/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -267,20 +267,24 @@ spec:
       - name: config
         secret:
           secretName: {{ template "opendistro-es.fullname" . }}-es-config
+          defaultMode: 0600
       {{- if .Values.elasticsearch.ssl.transport.existingCertSecret }}
       - name: transport-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.rest.enabled .Values.elasticsearch.ssl.rest.existingCertSecret }}
       - name: rest-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.rest.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.ssl.admin.enabled .Values.elasticsearch.ssl.admin.existingCertSecret }}
       - name: admin-certs
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
+          defaultMode: 0600
       {{- end }}
       {{- if and .Values.elasticsearch.securityConfig.config.securityConfigSecret .Values.elasticsearch.securityConfig.config.data }}
       - name: security-config


### PR DESCRIPTION
This PR fixes following elasticsearch warning regarding config files permissions.

```
[2021-12-01T10:48:05,501][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] Directory /usr/share/elasticsearch/config has insecure file permissions (should be 0700)
[2021-12-01T10:48:05,501][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/elasticsearch.yml has insecure file permissions (should be 0600)
[2021-12-01T10:48:05,502][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/log4j2.properties has insecure file permissions (should be 0600)
[2021-12-01T10:48:05,502][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/elk-transport-key.pem has insecure file permissions (should be 0600)
[2021-12-01T10:48:05,502][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/elk-transport-root-ca.pem has insecure file permissions (should be 0600)
[2021-12-01T10:48:05,503][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/elk-transport-crt.pem has insecure file permissions (should be 0600)
[2021-12-01T10:48:05,503][WARN ][c.a.o.s.OpenDistroSecurityPlugin] [efk-stack-app-opendistro-es-master-0] File /usr/share/elasticsearch/config/logging.yml has insecure file permissions (should be 0600)
```