### PR TITLE
Upgrade opendistro-es to v1.13.3

### DIFF
--- a/helm/efk-stack-app/charts/opendistro-es/Chart.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/Chart.yaml
@@ -13,7 +13,7 @@
 
 apiVersion: v1
 # Open Distro for Elasticsearch version
-appVersion: 1.13.2
+appVersion: 1.13.3
 description: 'Open Distro for Elasticsearch'
 engine: gotpl
 kubeVersion: ^1.10.0-0
@@ -26,4 +26,4 @@ name: opendistro-es
 sources:
 - https://pages.git.viasat.com/ATG/charts
 # Chart version
-version: 1.13.2
+version: 1.13.3

--- a/helm/efk-stack-app/charts/opendistro-es/values.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/values.yaml
@@ -540,7 +540,7 @@ elasticsearch:
   maxMapCount: 262144
 
   image: amazon/opendistro-for-elasticsearch
-  imageTag: 1.13.2
+  imageTag: 1.13.3
   ## Specifies the image pull policy. Can be "Always" or "IfNotPresent" or "Never".
   ## Default to "Always".
   imagePullPolicy: ""


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20168

Upgrade opendistro to v1.13.3 to fix CVE-2021-44228.

See https://opendistro.github.io/for-elasticsearch/blog/2021/12/update-to-1-13-3/

:warning:  Do not merge with github :warning: 