### PR TITLE
Set team annotation in Chart.yaml for alert routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Set team annotation in Chart.yaml for alert routing.
+
 ## [0.7.2] - 2021-12-16
 
 ### Fixed

--- a/helm/efk-stack-app/Chart.yaml
+++ b/helm/efk-stack-app/Chart.yaml
@@ -20,6 +20,8 @@ description: Open Distro for Elasticsearch
 engine: gotpl
 home: https://github.com/giantswarm/efk-stack-app
 icon: https://s.giantswarm.io/app-icons/1/png/efk-stack-app-light.png
+annotations:
+  application.giantswarm.io/team: "atlas"
 maintainers:
 - name: Giant Swarm applications team
   url: https://github.com/giantswarm/efk-stack-app


### PR DESCRIPTION
<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->

This PR:

- Adds setting the team annotation in Chart.yaml for alert routing.

### Checklist

- [x] Update changelog in CHANGELOG.md.

