### PR TITLE
Fix deprecated api version for RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Set team annotation in Chart.yaml for alert routing.
 
+### Fixed
+
+- Fix deprecated api version for rbac.
+
 ## [0.7.2] - 2021-12-16
 
 ### Fixed

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/templates/role.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/helm/efk-stack-app/charts/elasticsearch-exporter/templates/rolebinding.yaml
+++ b/helm/efk-stack-app/charts/elasticsearch-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/role.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}

--- a/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/rolebinding.yaml
+++ b/helm/efk-stack-app/charts/fluentd-elasticsearch/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.podSecurityPolicy.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "fluentd-elasticsearch.fullname" . }}

--- a/helm/efk-stack-app/charts/opendistro-certs/templates/rbac.yaml
+++ b/helm/efk-stack-app/charts/opendistro-certs/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "opendistro-certs.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "opendistro-certs.fullname" . }}

--- a/helm/efk-stack-app/charts/opendistro-es/templates/kibana/role.yaml
+++ b/helm/efk-stack-app/charts/opendistro-es/templates/kibana/role.yaml
@@ -13,7 +13,7 @@
 
 # @formatter:off
 {{- if and .Values.global.rbac.enabled .Values.kibana.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "opendistro-es.kibana.serviceAccountName" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21501

This PR:

- fixes deprecated rbac api version as rbac v1 exists since kubernetes 1.8

### Checklist

- [x] Update changelog in CHANGELOG.md.

